### PR TITLE
nagios: removed hard-coded telia links hotfix

### DIFF
--- a/nagios/nagios-client/scripts/check_link_traffic.sh
+++ b/nagios/nagios-client/scripts/check_link_traffic.sh
@@ -42,10 +42,7 @@ if [ "$curtime" -ne "$prevtime" ]; then
          old_down="$new_down"
          new_down=`echo "$headers" | cut -d' ' -f"$counter" | cut -d'-' -f1`
          if [ "$new_down" != "$old_down" ]; then
-            #hotfix for skipping telia links
-            if [ "$new_down" != "telia" ]; then
-               link_down=`echo "$link_down $new_down"`
-            fi
+            link_down=`echo "$link_down $new_down"`
          fi
          down_flag=1
       fi


### PR DESCRIPTION
Previous version of link_traffic module had names of links hard-coded in it. Now it reads from configuragion file. I removed hotfix that skipped telia link.