### PR TITLE
supervisor_cli: open log at the end of the file

### DIFF
--- a/internal.c
+++ b/internal.c
@@ -131,10 +131,10 @@ void show_file_with_pager(char **file_path)
    int status = 0;
 
    if (pid == 0) {
-      char *params[3];
+      // program parameters: prog_name, options, file_path, NULL
+      char *params[] = {NULL, PAGER_PARAMS NULL, NULL};
       params[0] = strdup(PAGER);
-      params[1] = *file_path;
-      params[2] = NULL;
+      params[sizeof(params)/sizeof(params[0])-2] = *file_path;
       execvp(PAGER, params);
       fprintf(stderr, "[ERROR] Execution of \"%s\" failed.\n", PAGER);
       exit(EXIT_FAILURE);

--- a/internal.h
+++ b/internal.h
@@ -82,6 +82,9 @@
 
 /* Log files are being shown with the following pager */
 #define PAGER "less"
+/* Parameters to pass to the pager (comma-separated list of strings, with a comma at the end) */
+#define PAGER_PARAMS "+G",
+
 #define SUP_TMP_DIR "/tmp/sup_tmp_dir"
 /* Tmp file used for additional communication between daemon and client (e.g. to keep log file name which is client gonna show) */
 #define SUP_CLI_TMP_FILE "/tmp/sup_tmp_dir/sup_cli_tmp_file"


### PR DESCRIPTION
Pass `+G` parameter to the `less` command when opening logs, so they are always opened at the end (which is what users usually need).

Implemented in a way that PAGER and its parameters are still easily configurable in the header file.

Quickly tested, works well.